### PR TITLE
Correct typo in results PNG download filename

### DIFF
--- a/components/DownloadPopup.vue
+++ b/components/DownloadPopup.vue
@@ -166,7 +166,7 @@ export default {
         canvas.then((canvas) => {
           downloadBase64File(
             canvas.toDataURL(),
-            "whatsanlayze-results-" + names + ".png"
+            "whatsanalyze-results-" + names + ".png"
           );
           this.loading = false;
         });


### PR DESCRIPTION
I noticed this when using whatsanalyze